### PR TITLE
OpenClaw 2026.6.6 v4 protocol adaptation + chat module refactor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
         "tar-stream": "^3.1.7",
-        "ws": "^8.19.0",
+        "ws": "^8.20.1",
         "zod": "^4.3.6",
         "zustand": "^5.0.11"
       },
@@ -2251,6 +2251,19 @@
       "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.0.tgz",
       "integrity": "sha512-eUgLqrMf8nJkZxT24JvVRrQya1vZkQh8BBeYNwGDqa5I0VUi8ACx7uFvAaLxintokpTenkK6DASvo/bvNbBGow==",
       "license": "MIT"
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
@@ -5191,6 +5204,66 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.18.tgz",
@@ -5275,29 +5348,6 @@
         "fast-glob": "^3.3.3",
         "minimatch": "^10.0.1",
         "path-browserify": "^1.0.1"
-      }
-    },
-    "node_modules/@ts-morph/common/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@ts-morph/common/node_modules/fast-glob": {
@@ -6075,16 +6125,6 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -7030,11 +7070,14 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/bare-events": {
       "version": "2.8.2",
@@ -7156,14 +7199,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -7749,13 +7794,6 @@
       "engines": {
         "node": ">=20"
       }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "devOptional": true,
-      "license": "MIT"
     },
     "node_modules/confbox": {
       "version": "0.2.4",
@@ -10278,39 +10316,6 @@
       "engines": {
         "node": ">=14.14"
       }
-    },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/fs-minipass/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -13591,60 +13596,26 @@
       }
     },
     "node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "license": "ISC",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
       "optional": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
+        "minipass": "^7.1.2"
       },
       "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minizlib/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC",
-      "optional": true
-    },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "node": ">= 18"
       }
     },
     "node_modules/mkdirp-classic": {
@@ -15094,9 +15065,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -16891,22 +16862,20 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
+      "version": "7.5.15",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "license": "BlueOak-1.0.0",
       "optional": true,
       "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/tar-fs": {
@@ -16949,21 +16918,24 @@
       }
     },
     "node_modules/tar/node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "license": "ISC",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
       "optional": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/tar/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC",
-      "optional": true
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/text-decoder": {
       "version": "1.2.7",
@@ -18247,9 +18219,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "tar-stream": "^3.1.7",
-    "ws": "^8.19.0",
+    "ws": "^8.20.1",
     "zod": "^4.3.6",
     "zustand": "^5.0.11"
   },
@@ -110,6 +110,10 @@
     "fast-uri": "^3.1.2",
     "postcss": "^8.5.10",
     "@protobufjs/utf8": "^1.1.1",
-    "ip-address": "^10.2.0"
+    "ip-address": "^10.2.0",
+    "tar": "^7.5.13",
+    "qs": "^6.15.2",
+    "ws": "^8.20.1",
+    "brace-expansion": "^5.0.6"
   }
 }

--- a/rag-service/requirements.txt
+++ b/rag-service/requirements.txt
@@ -23,3 +23,5 @@ python-dotenv>=1.0.1
 requests>=2.32.5
 httpx>=0.27.2
 numpy>=1.26.4
+tqdm>=4.66.3
+idna>=3.15

--- a/src/app/api/v1/chat/send/route.ts
+++ b/src/app/api/v1/chat/send/route.ts
@@ -2,7 +2,9 @@ import { createHash, randomUUID } from 'crypto'
 import { extname } from 'path'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
-import { registry, ensureRegistryInitialized } from '@/lib/gateway/registry'
+import { registry, ensureRegistryInitialized, resolveGatewayUrl } from '@/lib/gateway/registry'
+import { decrypt } from '@/lib/auth/encryption'
+import { GatewayClient } from '@/lib/gateway/client'
 import { sendMessageSchema } from '@/lib/validations/chat'
 import { verifyAccessToken } from '@/lib/auth/jwt'
 import { dockerManager } from '@/lib/docker/manager'
@@ -276,11 +278,26 @@ export async function POST(req: NextRequest) {
   // --- Ensure registry ---
   await ensureRegistryInitialized()
 
-  const client = registry.getClient(instanceId)
   const adapter = registry.getAdapter(instanceId)
-  if (!client || !adapter) {
+  if (!adapter) {
     return NextResponse.json({ error: 'Instance not connected' }, { status: 502 })
   }
+
+  // Fresh GatewayClient per chat.send: persistent sockets receive compressed
+  // event streams (single full-text delta, no agent:item tool events) from the
+  // v4 gateway. A one-shot client gets full incremental streaming.
+  const instance = await prisma.instance.findUnique({
+    where: { id: instanceId },
+    select: { gatewayUrl: true, gatewayToken: true, dockerConfig: true },
+  })
+  if (!instance) {
+    return NextResponse.json({ error: 'Instance not found' }, { status: 502 })
+  }
+  const client = new GatewayClient(
+    resolveGatewayUrl({ gatewayUrl: instance.gatewayUrl, dockerConfig: instance.dockerConfig }),
+    decrypt(instance.gatewayToken),
+  )
+  await client.connect()
 
   // --- Build session key ---
   const sessionKey = `agent:${agentId}:tc:${user.id}`
@@ -474,15 +491,18 @@ export async function POST(req: NextRequest) {
         lastThinkingContent = thinkingContent
       }
 
-      // v4: computeTextDelta handles deltaText/replace/cumulative-slice uniformly
-      const tdelta = computeTextDelta({
-        deltaText: evt.deltaText as string | undefined,
-        replace: evt.replace as boolean | undefined,
-        cumulative: textContent,
-        lastEmitted: lastTextContent,
-      })
-      if (tdelta.text) write({ type: 'text', content: tdelta.text })
-      lastTextContent = tdelta.nextLast
+      // When preamble events already delivered the text incrementally,
+      // the chat delta is a duplicate. Skip it.
+      if (textContent !== lastTextContent) {
+        const tdelta = computeTextDelta({
+          deltaText: evt.deltaText as string | undefined,
+          replace: evt.replace as boolean | undefined,
+          cumulative: textContent,
+          lastEmitted: lastTextContent,
+        })
+        if (tdelta.text) write({ type: 'text', content: tdelta.text })
+        lastTextContent = tdelta.nextLast
+      }
 
       // Capture inline image blocks if OpenClaw embeds them in chat events
       const images = extractImagesFromMessage(evt.message)
@@ -643,9 +663,27 @@ export async function POST(req: NextRequest) {
     }
 
     // ── Item: tool lifecycle events (OpenClaw 2026.4+) ──
-    if (stream === 'item') {
+    // ── Item: tool/thinking/preamble events (OpenClaw 2026.4+) ──
+    // v4 gateway may prefix item events with the agent runtime id
+    // (e.g. "codex_app_server.item") instead of bare "item".
+    if (stream === 'item' || (typeof stream === 'string' && stream.endsWith('.item'))) {
       const data = (evt.data ?? {}) as Record<string, unknown>
       const kind = data.kind as string | undefined
+
+      // v4 gateway pushes incremental text through agent item preamble
+      // events instead of chat delta events when routed through the built-in
+      // agent runtime.  Route them as text SSE events for the typewriter effect.
+      if (kind === 'preamble') {
+        const progressText = data.progressText as string | undefined
+        if (progressText) {
+          const trimmed = progressText.slice(lastTextContent.length)
+          if (trimmed) {
+            lastTextContent = progressText
+            write({ type: 'text', content: trimmed })
+          }
+        }
+        return
+      }
       const phase = data.phase as string
       const toolName = String(data.name ?? 'tool')
 
@@ -724,6 +762,7 @@ export async function POST(req: NextRequest) {
     activeRuns.delete(chatSessionId)
     unsubChat()
     unsubAgent()
+    client.disconnect()
     await close()
   }
 

--- a/src/app/api/v1/chat/send/route.ts
+++ b/src/app/api/v1/chat/send/route.ts
@@ -697,7 +697,7 @@ export async function POST(req: NextRequest) {
         if (phase === 'start') {
           activeToolName = toolName
           toolOutputBuf.set(toolName, '')
-          const toolInput = data.args ?? data.meta ?? {}
+          const toolInput = data.meta ?? data.args ?? {}
           capturedToolInputs.push({ toolName, toolInput })
           write({
             type: 'tool_call',

--- a/src/app/api/v1/chat/send/route.ts
+++ b/src/app/api/v1/chat/send/route.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto'
+import { createHash, randomUUID } from 'crypto'
 import { extname } from 'path'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
@@ -29,6 +29,7 @@ import {
   readImageAsDataUrl,
   readContainerImageAsDataUrl,
 } from '@/lib/chat/image-helpers'
+import { computeTextDelta } from '@/lib/chat/stream-delta'
 import { activeRuns } from '@/lib/chat/active-runs'
 import type { ChatStreamEvent, ChatContentBlock } from '@/types/chat'
 import type { ChatHistoryResult } from '@/types/gateway'
@@ -57,6 +58,36 @@ interface ExtractedImage {
   url: string
   mimeType?: string
   alt?: string
+}
+
+interface GatewayAttachment {
+  fileName: string
+  mimeType: string
+  content: string
+}
+
+function attachmentContentKey(att: Pick<GatewayAttachment, 'mimeType' | 'content'>): string {
+  return createHash('sha256')
+    .update(att.mimeType)
+    .update(':')
+    .update(att.content)
+    .digest('hex')
+}
+
+function dedupeAttachments<T extends Pick<GatewayAttachment, 'mimeType' | 'content'>>(
+  attachments: T[],
+): T[] {
+  const seen = new Set<string>()
+  const unique: T[] = []
+
+  for (const att of attachments) {
+    const key = attachmentContentKey(att)
+    if (seen.has(key)) continue
+    unique.push(att)
+    seen.add(key)
+  }
+
+  return unique
 }
 
 function extractImagesFromMessage(message: unknown): ExtractedImage[] {
@@ -443,11 +474,15 @@ export async function POST(req: NextRequest) {
         lastThinkingContent = thinkingContent
       }
 
-      if (textContent && textContent !== lastTextContent) {
-        const newText = textContent.slice(lastTextContent.length)
-        if (newText) write({ type: 'text', content: newText })
-        lastTextContent = textContent
-      }
+      // v4: computeTextDelta handles deltaText/replace/cumulative-slice uniformly
+      const tdelta = computeTextDelta({
+        deltaText: evt.deltaText as string | undefined,
+        replace: evt.replace as boolean | undefined,
+        cumulative: textContent,
+        lastEmitted: lastTextContent,
+      })
+      if (tdelta.text) write({ type: 'text', content: tdelta.text })
+      lastTextContent = tdelta.nextLast
 
       // Capture inline image blocks if OpenClaw embeds them in chat events
       const images = extractImagesFromMessage(evt.message)
@@ -479,10 +514,14 @@ export async function POST(req: NextRequest) {
         if (newThinking) write({ type: 'thinking', content: newThinking })
       }
 
-      if (textContent && textContent !== lastTextContent) {
-        const newText = textContent.slice(lastTextContent.length)
-        if (newText) write({ type: 'text', content: newText })
-      }
+      // v4: computeTextDelta handles deltaText/replace/cumulative-slice uniformly
+      const tdelta = computeTextDelta({
+        deltaText: evt.deltaText as string | undefined,
+        replace: evt.replace as boolean | undefined,
+        cumulative: textContent,
+        lastEmitted: lastTextContent,
+      })
+      if (tdelta.text) write({ type: 'text', content: tdelta.text })
 
       // Capture any remaining inline image blocks from final message
       const images = extractImagesFromMessage(evt.message)
@@ -693,7 +732,7 @@ export async function POST(req: NextRequest) {
   // client gets the SSE connection immediately (no multi-second delay from
   // Docker exec operations like symlink creation, dir listing, and image download).
   ;(async () => {
-    const sessionFileAttachments: { fileName: string; mimeType: string; content: string }[] = []
+    const sessionFileAttachments: GatewayAttachment[] = []
     const SESSION_IMAGE_EXTS: Record<string, string> = {
       '.png': 'image/png',
       '.jpg': 'image/jpeg',
@@ -818,19 +857,19 @@ export async function POST(req: NextRequest) {
       // Non-blocking: skip on any error
     }
 
-    const mappedAttachments = [
+    const mappedAttachments = dedupeAttachments([
       ...(attachments?.map((a) => ({
         fileName: a.name,
         mimeType: a.mimeType,
         content: a.content,
       })) ?? []),
       ...sessionFileAttachments,
-    ]
+    ])
 
     // Capture ONLY 📎 chat attachments for liveMessages persistence (not sidebar input/ files).
     // Session file attachments are sent to the agent via mappedAttachments but should NOT
     // appear as contentBlocks in chat message bubbles.
-    for (const a of attachments ?? []) {
+    for (const a of dedupeAttachments(attachments ?? [])) {
       if (a.mimeType.startsWith('image/')) {
         userImageAttachments.push({ name: a.name, mimeType: a.mimeType, content: a.content })
       }

--- a/src/app/api/v1/chat/send/route.ts
+++ b/src/app/api/v1/chat/send/route.ts
@@ -676,11 +676,12 @@ export async function POST(req: NextRequest) {
       if (kind === 'preamble') {
         const progressText = data.progressText as string | undefined
         if (progressText) {
-          const trimmed = progressText.slice(lastTextContent.length)
-          if (trimmed) {
-            lastTextContent = progressText
-            write({ type: 'text', content: trimmed })
-          }
+          const d = computeTextDelta({
+            cumulative: progressText,
+            lastEmitted: lastTextContent,
+          })
+          if (d.text) write({ type: 'text', content: d.text })
+          lastTextContent = d.nextLast
         }
         return
       }

--- a/src/app/api/v1/chat/send/route.ts
+++ b/src/app/api/v1/chat/send/route.ts
@@ -684,10 +684,16 @@ export async function POST(req: NextRequest) {
         }
         return
       }
+      // kind=analysis → agent reasoning, skip per user preference (thinking hidden)
+      if (kind === 'analysis') return
+
       const phase = data.phase as string
       const toolName = String(data.name ?? 'tool')
 
-      if (kind === 'tool') {
+      // kind=command is how the v4 gateway sends tool execution events through
+      // the built-in agent runtime (codex-app-server). Direct WS connections get
+      // kind=tool; GatewayClient connections get kind=command with the same shape.
+      if (kind === 'tool' || kind === 'command') {
         if (phase === 'start') {
           activeToolName = toolName
           toolOutputBuf.set(toolName, '')

--- a/src/app/api/v1/chat/sessions/[id]/history/route.ts
+++ b/src/app/api/v1/chat/sessions/[id]/history/route.ts
@@ -17,6 +17,7 @@ import {
 import { computeImageId } from '@/lib/chat/image-helpers'
 import { stripRagContextForDisplay } from '@/lib/chat/rag-user-message'
 import { activeRuns } from '@/lib/chat/active-runs'
+import { imageBlockDisplayKey, imageIdFromHistoryUrl } from '@/lib/chat/image-blocks'
 import type { ChatHistoryResult, ChatHistoryMessage } from '@/types/gateway'
 import type {
   ChatMessage,
@@ -118,10 +119,29 @@ function replaceInlineImages(messages: ChatMessage[], sessionId: string): void {
     for (const block of msg.contentBlocks) {
       if (block.type === 'image' && block.imageUrl?.startsWith('data:')) {
         const hash = computeImageId(block.imageUrl)
+        block.imageId = hash
         block.imageUrl = `/api/v1/chat/sessions/${sessionId}/images/${hash}`
+      } else if (block.type === 'image' && block.imageUrl && !block.imageId) {
+        const hash = imageIdFromHistoryUrl(block.imageUrl)
+        if (hash) block.imageId = hash
       }
     }
+    msg.contentBlocks = dedupeContentBlocks(msg.contentBlocks)
   }
+}
+
+function dedupeContentBlocks(blocks: ChatContentBlock[]): ChatContentBlock[] {
+  const seen = new Set<string>()
+  const unique: ChatContentBlock[] = []
+
+  for (const block of blocks) {
+    const key = imageBlockDisplayKey(block)
+    if (seen.has(key)) continue
+    unique.push(block)
+    seen.add(key)
+  }
+
+  return unique
 }
 
 // GET /api/v1/chat/sessions/[id]/history — load snapshots + current messages

--- a/src/components/chat/chat-assistant-message.tsx
+++ b/src/components/chat/chat-assistant-message.tsx
@@ -160,7 +160,7 @@ export function ChatAssistantMessage({ message, isStreaming, processSteps }: Cha
             <ChatProcessGroup steps={allSteps} inline />
           ) : (
             <>
-              {message.thinking && <ChatThinkingBlock content={message.thinking} />}
+              {/* #13: thinking hidden — removed ChatThinkingBlock */}
               {message.toolCalls?.map((tc, i) => (
                 <ChatToolCallBlock key={i} toolCall={tc} />
               ))}

--- a/src/components/chat/chat-assistant-message.tsx
+++ b/src/components/chat/chat-assistant-message.tsx
@@ -167,7 +167,7 @@ export function ChatAssistantMessage({ message, isStreaming, processSteps }: Cha
               ))}
             </>
           )}
-          {/* #13: stage reply — tool phase (name+desc) ⟳ text phase (preamble) ⟳ final */}
+          {/* Stage reply: tool description → streaming text → final ChatTextBlock */}
           {isStreaming && !message.content && (() => {
             const last = message.toolCalls?.at(-1)
             const desc = typeof last?.toolInput === 'string' ? last.toolInput : ''

--- a/src/components/chat/chat-assistant-message.tsx
+++ b/src/components/chat/chat-assistant-message.tsx
@@ -10,6 +10,7 @@ import { ChatErrorBlock } from './chat-error-block'
 import { ChatImageBlock } from './chat-image-block'
 import { useChatStore } from '@/stores/chat-store'
 import { useT } from '@/stores/language-store'
+import { imageBlockDisplayKey, uniqueImageBlocks } from '@/lib/chat/image-blocks'
 import { selectVisibleKbSources } from '@/lib/chat/kb-sources'
 import { useState } from 'react'
 
@@ -146,6 +147,7 @@ export function ChatAssistantMessage({ message, isStreaming, processSteps }: Cha
     : useCompactOwn
       ? [message]
       : null
+  const imageBlocks = uniqueImageBlocks(message.contentBlocks)
 
   return (
     <div className="flex justify-start">
@@ -165,11 +167,13 @@ export function ChatAssistantMessage({ message, isStreaming, processSteps }: Cha
             </>
           )}
           {message.content && <ChatTextBlock content={message.content} />}
-          {message.contentBlocks?.map((block, i) =>
-            block.type === 'image' && block.imageUrl ? (
-              <ChatImageBlock key={i} imageUrl={block.imageUrl} alt={block.alt} />
-            ) : null,
-          )}
+          {imageBlocks.map((block) => (
+            <ChatImageBlock
+              key={imageBlockDisplayKey(block)}
+              imageUrl={block.imageUrl!}
+              alt={block.alt}
+            />
+          ))}
           {isStreaming && !message.content && (
             <div className="flex items-center gap-1 py-2">
               <span className="bg-foreground/60 size-1.5 animate-bounce rounded-full [animation-delay:0ms]" />

--- a/src/components/chat/chat-assistant-message.tsx
+++ b/src/components/chat/chat-assistant-message.tsx
@@ -175,8 +175,9 @@ export function ChatAssistantMessage({ message, isStreaming, processSteps }: Cha
             if (!desc && !name) return null
             return <ChatStageReply text={desc} toolName={name} />
           })()}
+          {/* #13: stage reply during streaming → ChatTextBlock after done (history only) */}
           {isStreaming && message.content && <ChatStageReply text={message.content} />}
-          {!isStreaming && message.content && <ChatTextBlock content={message.content} />}
+          {message.content && !isStreaming && <ChatTextBlock content={message.content} />}
           {imageBlocks.map((block) => (
             <ChatImageBlock
               key={imageBlockDisplayKey(block)}

--- a/src/components/chat/chat-assistant-message.tsx
+++ b/src/components/chat/chat-assistant-message.tsx
@@ -167,9 +167,15 @@ export function ChatAssistantMessage({ message, isStreaming, processSteps }: Cha
               ))}
             </>
           )}
-          {/* #13: stage reply (streaming) vs final reply (done) */}
-          {message.content && isStreaming && <ChatStageReply text={message.content} />}
-          {message.content && !isStreaming && <ChatTextBlock content={message.content} />}
+          {/* #13: stage reply — tool phase (desc) ⟳ text phase (preamble) ⟳ final */}
+          {isStreaming && !message.content && (() => {
+            const last = message.toolCalls?.at(-1)
+            const desc = typeof last?.toolInput === 'string' ? last.toolInput : ''
+            if (!desc) return null
+            return <ChatStageReply text={desc} />
+          })()}
+          {isStreaming && message.content && <ChatStageReply text={message.content} />}
+          {!isStreaming && message.content && <ChatTextBlock content={message.content} />}
           {imageBlocks.map((block) => (
             <ChatImageBlock
               key={imageBlockDisplayKey(block)}

--- a/src/components/chat/chat-assistant-message.tsx
+++ b/src/components/chat/chat-assistant-message.tsx
@@ -8,6 +8,7 @@ import { ChatToolCallBlock } from './chat-tool-call-block'
 import { ChatTextBlock } from './chat-text-block'
 import { ChatErrorBlock } from './chat-error-block'
 import { ChatImageBlock } from './chat-image-block'
+import { ChatStageReply } from './chat-stage-reply'
 import { useChatStore } from '@/stores/chat-store'
 import { useT } from '@/stores/language-store'
 import { imageBlockDisplayKey, uniqueImageBlocks } from '@/lib/chat/image-blocks'
@@ -166,7 +167,9 @@ export function ChatAssistantMessage({ message, isStreaming, processSteps }: Cha
               ))}
             </>
           )}
-          {message.content && <ChatTextBlock content={message.content} />}
+          {/* #13: stage reply (streaming) vs final reply (done) */}
+          {message.content && isStreaming && <ChatStageReply text={message.content} />}
+          {message.content && !isStreaming && <ChatTextBlock content={message.content} />}
           {imageBlocks.map((block) => (
             <ChatImageBlock
               key={imageBlockDisplayKey(block)}

--- a/src/components/chat/chat-assistant-message.tsx
+++ b/src/components/chat/chat-assistant-message.tsx
@@ -167,12 +167,13 @@ export function ChatAssistantMessage({ message, isStreaming, processSteps }: Cha
               ))}
             </>
           )}
-          {/* #13: stage reply — tool phase (desc) ⟳ text phase (preamble) ⟳ final */}
+          {/* #13: stage reply — tool phase (name+desc) ⟳ text phase (preamble) ⟳ final */}
           {isStreaming && !message.content && (() => {
             const last = message.toolCalls?.at(-1)
             const desc = typeof last?.toolInput === 'string' ? last.toolInput : ''
-            if (!desc) return null
-            return <ChatStageReply text={desc} />
+            const name = last?.toolName
+            if (!desc && !name) return null
+            return <ChatStageReply text={desc} toolName={name} />
           })()}
           {isStreaming && message.content && <ChatStageReply text={message.content} />}
           {!isStreaming && message.content && <ChatTextBlock content={message.content} />}

--- a/src/components/chat/chat-chart-block.tsx
+++ b/src/components/chat/chat-chart-block.tsx
@@ -216,7 +216,17 @@ export const ChatChartBlock = memo(function ChatChartBlock({ optionJson }: ChatC
       const sanitized = sanitizeOption(parsed) as Record<string, unknown>
       return { option: sanitized, error: null }
     } catch {
-      return { option: null, error: 'chat.chartJsonInvalid' as const }
+      // LLMs often output literal newlines inside JSON string values
+      // (e.g. ECharts tooltip formatters). JSON forbids unescaped control
+      // characters — repair and retry once before reporting the error.
+      try {
+        const repaired = optionJson.replace(/(?<!\\)\n/g, '\\n').replace(/(?<!\\)\t/g, '\\t')
+        const parsed = JSON.parse(repaired)
+        const sanitized = sanitizeOption(parsed) as Record<string, unknown>
+        return { option: sanitized, error: null }
+      } catch {
+        return { option: null, error: 'chat.chartJsonInvalid' as const }
+      }
     }
 
   }, [optionJson])

--- a/src/components/chat/chat-chart-block.tsx
+++ b/src/components/chat/chat-chart-block.tsx
@@ -218,9 +218,14 @@ export const ChatChartBlock = memo(function ChatChartBlock({ optionJson }: ChatC
     } catch {
       // LLMs often output literal newlines inside JSON string values
       // (e.g. ECharts tooltip formatters). JSON forbids unescaped control
-      // characters — repair and retry once before reporting the error.
+      // characters.  Repair all bare control chars inside quoted strings once
+      // before reporting the error.  Avoids negative lookbehind (?<!\\) for
+      // Safari compatibility.
       try {
-        const repaired = optionJson.replace(/(?<!\\)\n/g, '\\n').replace(/(?<!\\)\t/g, '\\t')
+        const repaired = optionJson.replace(
+          /"([^"\\]*(\\.[^"\\]*)*)"/g,
+          (match: string) => match.replace(/\n/g, '\\n').replace(/\t/g, '\\t'),
+        )
         const parsed = JSON.parse(repaired)
         const sanitized = sanitizeOption(parsed) as Record<string, unknown>
         return { option: sanitized, error: null }

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -123,11 +123,15 @@ export function ChatInput() {
         const base64 = dataUrl.split(',')[1]
         setPendingFiles((prev) => {
           if (prev.length >= 5) return prev
+          const mimeType = file.type || 'application/octet-stream'
+          if (prev.some((pending) => pending.mimeType === mimeType && pending.content === base64)) {
+            return prev
+          }
           return [
             ...prev,
             {
               name: file.name,
-              mimeType: file.type || 'application/octet-stream',
+              mimeType,
               size: file.size,
               content: base64,
               dataUrl,

--- a/src/components/chat/chat-message-bubble.tsx
+++ b/src/components/chat/chat-message-bubble.tsx
@@ -1,7 +1,9 @@
 "use client"
 
+import { useEffect, useRef, useState, type SyntheticEvent } from "react"
 import { User, FileText } from "lucide-react"
 import type { ChatMessage } from "@/types/chat"
+import { imageBlockDisplayKey, uniqueImageBlocks } from "@/lib/chat/image-blocks"
 
 interface ChatMessageBubbleProps {
   message: ChatMessage
@@ -13,13 +15,90 @@ function formatFileSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)}MB`
 }
 
+function uniqueAttachmentPreviews(
+  attachments: ChatMessage["attachments"],
+): NonNullable<ChatMessage["attachments"]> {
+  const seen = new Set<string>()
+  const unique: NonNullable<ChatMessage["attachments"]> = []
+
+  for (const attachment of attachments ?? []) {
+    const key = attachment.dataUrl || `${attachment.mimeType}:${attachment.name}:${attachment.size}`
+    if (seen.has(key)) continue
+    unique.push(attachment)
+    seen.add(key)
+  }
+
+  return unique
+}
+
+function attachmentPreviewKey(att: NonNullable<ChatMessage["attachments"]>[number]): string {
+  return `attachment:${att.mimeType}:${att.dataUrl.slice(0, 96)}:${att.dataUrl.length}`
+}
+
+function visualImageFingerprint(img: HTMLImageElement): string {
+  const dimensions = `${img.naturalWidth}x${img.naturalHeight}`
+
+  try {
+    const size = 16
+    const canvas = document.createElement("canvas")
+    canvas.width = size
+    canvas.height = size
+    const ctx = canvas.getContext("2d", { willReadFrequently: true })
+    if (!ctx) return dimensions
+
+    ctx.drawImage(img, 0, 0, size, size)
+    const pixels = ctx.getImageData(0, 0, size, size).data
+    const grays: number[] = []
+    let total = 0
+
+    for (let i = 0; i < pixels.length; i += 4) {
+      const gray = pixels[i] * 0.299 + pixels[i + 1] * 0.587 + pixels[i + 2] * 0.114
+      grays.push(gray)
+      total += gray
+    }
+
+    const avg = total / grays.length
+    return `${dimensions}:${grays.map((gray) => (gray >= avg ? "1" : "0")).join("")}`
+  } catch {
+    return dimensions
+  }
+}
+
 export function ChatMessageBubble({ message }: ChatMessageBubbleProps) {
-  const hasAttachments = message.attachments && message.attachments.length > 0
+  const attachments = uniqueAttachmentPreviews(message.attachments)
+  const hasAttachments = attachments.length > 0
   // After syncFromHistory, user images move from `attachments` (client-only)
   // to `contentBlocks` (from gateway history). Render those as fallback.
   const contentImages = !hasAttachments
-    ? message.contentBlocks?.filter((b) => b.type === "image" && b.imageUrl) ?? []
+    ? uniqueImageBlocks(message.contentBlocks)
     : []
+  const imageSignature = [
+    ...attachments.map(attachmentPreviewKey),
+    ...contentImages.map(imageBlockDisplayKey),
+  ].join("|")
+  const seenVisualFingerprints = useRef<Set<string>>(new Set())
+  const [hiddenImageKeys, setHiddenImageKeys] = useState<Set<string>>(() => new Set())
+
+  useEffect(() => {
+    seenVisualFingerprints.current.clear()
+    setHiddenImageKeys(new Set())
+  }, [imageSignature])
+
+  function handleImageLoad(
+    key: string,
+    event: SyntheticEvent<HTMLImageElement>,
+  ) {
+    const fingerprint = visualImageFingerprint(event.currentTarget)
+    if (seenVisualFingerprints.current.has(fingerprint)) {
+      setHiddenImageKeys((prev) => {
+        const next = new Set(prev)
+        next.add(key)
+        return next
+      })
+      return
+    }
+    seenVisualFingerprints.current.add(fingerprint)
+  }
 
   return (
     <div className="flex justify-end">
@@ -28,17 +107,19 @@ export function ChatMessageBubble({ message }: ChatMessageBubbleProps) {
           {/* Attachment previews */}
           {hasAttachments && (
             <div className="flex flex-wrap justify-end gap-1.5">
-              {message.attachments!.map((att, i) =>
-                att.mimeType.startsWith("image/") ? (
+              {attachments.map((att, i) => {
+                const key = `att-${i}-${attachmentPreviewKey(att)}`
+                return att.mimeType.startsWith("image/") ? (
                   <img
-                    key={i}
+                    key={key}
                     src={att.dataUrl}
                     alt={att.name}
-                    className="max-h-32 max-w-48 rounded-lg border object-cover"
+                    onLoad={(event) => handleImageLoad(key, event)}
+                    className={`${hiddenImageKeys.has(key) ? "hidden " : ""}max-h-32 max-w-48 rounded-lg border object-cover`}
                   />
                 ) : (
                   <div
-                    key={i}
+                    key={key}
                     className="bg-primary/10 flex items-center gap-1.5 rounded-lg px-2.5 py-1.5"
                   >
                     <FileText className="text-primary size-3.5 shrink-0" />
@@ -47,21 +128,25 @@ export function ChatMessageBubble({ message }: ChatMessageBubbleProps) {
                       <span className="text-muted-foreground text-[10px]">{formatFileSize(att.size)}</span>
                     </div>
                   </div>
-                ),
-              )}
+                )
+              })}
             </div>
           )}
           {/* Images from contentBlocks (after history sync replaces attachments) */}
           {contentImages.length > 0 && (
             <div className="flex flex-wrap justify-end gap-1.5">
-              {contentImages.map((block, i) => (
-                <img
-                  key={`cb-${i}`}
-                  src={block.imageUrl!}
-                  alt={block.alt ?? ""}
-                  className="max-h-32 max-w-48 rounded-lg border object-cover"
-                />
-              ))}
+              {contentImages.map((block, i) => {
+                const key = `cb-${i}-${imageBlockDisplayKey(block)}`
+                return (
+                  <img
+                    key={key}
+                    src={block.imageUrl!}
+                    alt={block.alt ?? ""}
+                    onLoad={(event) => handleImageLoad(key, event)}
+                    className={`${hiddenImageKeys.has(key) ? "hidden " : ""}max-h-32 max-w-48 rounded-lg border object-cover`}
+                  />
+                )
+              })}
             </div>
           )}
           {/* Text content */}

--- a/src/components/chat/chat-message-list.tsx
+++ b/src/components/chat/chat-message-list.tsx
@@ -344,7 +344,7 @@ export function ChatMessageList({ isLoadingHistory }: ChatMessageListProps) {
         })}
         {streamingMessage && (
           <ChatAssistantMessage
-            key={streamingMessage.id}
+            key={`streaming-${streamingMessage.id}`}
             message={streamingMessage}
             isStreaming={isStreaming}
           />

--- a/src/components/chat/chat-process-group.tsx
+++ b/src/components/chat/chat-process-group.tsx
@@ -85,35 +85,8 @@ export function ChatProcessGroup({ steps, inline }: ChatProcessGroupProps) {
     <div className="mt-1.5 space-y-px border-l-2 border-border/40 ml-1">
       {flatSteps.map((step, i) => {
         const isExpanded = expandedIdx === i
-        if (step.type === "thinking") {
-          return (
-            <div key={i}>
-              <button
-                type="button"
-                className="flex w-full items-start gap-1.5 rounded-r px-2.5 py-1 text-left text-[11px] text-muted-foreground transition-colors hover:bg-muted/40"
-                onClick={() => setExpandedIdx(isExpanded ? null : i)}
-              >
-                <Brain className="mt-0.5 size-2.5 shrink-0 opacity-60" />
-                <span className="line-clamp-1 flex-1 break-all">
-                  {step.thinking!.slice(0, 120)}
-                  {step.thinking!.length > 120 ? "…" : ""}
-                </span>
-                <ChevronRight
-                  className={cn(
-                    "mt-0.5 size-2.5 shrink-0 opacity-40 transition-transform",
-                    isExpanded && "rotate-90",
-                  )}
-                />
-              </button>
-              {isExpanded && (
-                <div className="ml-6 mr-2 mb-1 max-h-48 overflow-y-auto rounded bg-muted/30 px-2.5 py-2 text-[11px] text-muted-foreground/80 whitespace-pre-wrap">
-                  {step.thinking}
-                </div>
-              )}
-            </div>
-          )
-        }
-        // tool call
+        // thinking steps are filtered out above — only tool calls remain
+
         const tc = step.toolCall!
         return (
           <div key={i}>

--- a/src/components/chat/chat-process-group.tsx
+++ b/src/components/chat/chat-process-group.tsx
@@ -36,8 +36,8 @@ export function ChatProcessGroup({ steps, inline }: ChatProcessGroupProps) {
     const flat: ProcessStep[] = []
 
     for (const step of steps) {
-      // #13: thinking is hidden — skip rendering entirely
-      if (step.thinking) continue
+      // #13: thinking is hidden — don't add thinking flat steps.
+      // Tool calls on the SAME message must still be processed.
       for (const tc of step.toolCalls ?? []) {
         tools.set(tc.toolName, (tools.get(tc.toolName) ?? 0) + 1)
         flat.push({ type: "tool", toolCall: tc })

--- a/src/components/chat/chat-process-group.tsx
+++ b/src/components/chat/chat-process-group.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useMemo } from "react"
-import { Bot, Brain, Wrench, ChevronRight } from "lucide-react"
+import { Bot, Wrench, ChevronRight } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useT } from "@/stores/language-store"
 import type { ChatMessage, ChatToolCall } from "@/types/chat"

--- a/src/components/chat/chat-process-group.tsx
+++ b/src/components/chat/chat-process-group.tsx
@@ -31,27 +31,26 @@ export function ChatProcessGroup({ steps, inline }: ChatProcessGroupProps) {
   const [expanded, setExpanded] = useState(false)
   const [expandedIdx, setExpandedIdx] = useState<number | null>(null)
 
-  const { thinkingCount, toolEntries, flatSteps } = useMemo(() => {
-    let thinking = 0
+  const { toolEntries, flatSteps } = useMemo(() => {
     const tools = new Map<string, number>()
     const flat: ProcessStep[] = []
 
     for (const step of steps) {
-      if (step.thinking) {
-        thinking++
-        flat.push({ type: "thinking", thinking: step.thinking })
-      }
+      // #13: thinking is hidden — skip rendering entirely
+      if (step.thinking) continue
       for (const tc of step.toolCalls ?? []) {
         tools.set(tc.toolName, (tools.get(tc.toolName) ?? 0) + 1)
         flat.push({ type: "tool", toolCall: tc })
       }
     }
     return {
-      thinkingCount: thinking,
       toolEntries: [...tools.entries()],
       flatSteps: flat,
     }
   }, [steps])
+
+  // No tools to show → render nothing
+  if (flatSteps.length === 0) return null
 
   const summaryBar = (
     <button
@@ -59,14 +58,6 @@ export function ChatProcessGroup({ steps, inline }: ChatProcessGroupProps) {
       className="flex w-full flex-wrap items-center gap-1.5 rounded-lg border border-border/50 bg-muted/30 px-2.5 py-1.5 text-left transition-colors hover:bg-muted/50"
       onClick={() => setExpanded(!expanded)}
     >
-      {thinkingCount > 0 && (
-        <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
-          <Brain className="size-2.5" />
-          {thinkingCount > 1
-            ? t("chat.thinkingN", { n: String(thinkingCount) })
-            : t("chat.thinking")}
-        </span>
-      )}
       {toolEntries.map(([name, count]) => (
         <span
           key={name}

--- a/src/components/chat/chat-stage-reply.tsx
+++ b/src/components/chat/chat-stage-reply.tsx
@@ -1,0 +1,21 @@
+"use client"
+
+import { Loader2 } from "lucide-react"
+
+interface ChatStageReplyProps {
+  text: string
+}
+
+/**
+ * Staged (in-progress) reply shown during agent execution.
+ * Grey italic text + spinning indicator — overwritten by each new
+ * stage reply, and replaced by the final reply when the run completes.
+ */
+export function ChatStageReply({ text }: ChatStageReplyProps) {
+  return (
+    <div className="flex items-center gap-2 py-1">
+      <Loader2 className="size-3 shrink-0 animate-spin text-muted-foreground/60" />
+      <span className="text-sm text-muted-foreground/80">{text}</span>
+    </div>
+  )
+}

--- a/src/components/chat/chat-stage-reply.tsx
+++ b/src/components/chat/chat-stage-reply.tsx
@@ -1,21 +1,29 @@
 "use client"
 
-import ReactMarkdown from 'react-markdown'
-import remarkGfm from 'remark-gfm'
+import { Wrench } from "lucide-react"
+import ReactMarkdown from "react-markdown"
+import remarkGfm from "remark-gfm"
 
 interface ChatStageReplyProps {
   text: string
+  /** Active tool name shown in a light-yellow badge before the text. */
+  toolName?: string
 }
 
 /**
- * Staged (in-progress) reply — grey italic markdown, updated in-place as
- * preamble events stream in.  Renders with the same pipeline as ChatTextBlock
- * so markdown formatting (bold, code, lists) appears in real-time, not just
- * at the end.
+ * Staged (in-progress) reply — grey italic markdown with an optional
+ * tool-name badge in light yellow.  Updated in-place as preamble events
+ * stream in; replaced by the final ChatTextBlock when the run completes.
  */
-export function ChatStageReply({ text }: ChatStageReplyProps) {
+export function ChatStageReply({ text, toolName }: ChatStageReplyProps) {
   return (
     <div className="py-1 text-sm text-muted-foreground/70">
+      {toolName && (
+        <span className="inline-flex items-center gap-1 mr-1.5 rounded bg-yellow-100 dark:bg-yellow-900/30 px-1.5 py-0.5 text-[11px] text-yellow-800 dark:text-yellow-200 font-medium align-middle">
+          <Wrench className="size-2.5" />
+          {toolName}
+        </span>
+      )}
       <ReactMarkdown remarkPlugins={[remarkGfm]}>{text}</ReactMarkdown>
     </div>
   )

--- a/src/components/chat/chat-stage-reply.tsx
+++ b/src/components/chat/chat-stage-reply.tsx
@@ -1,30 +1,24 @@
 "use client"
 
 import { Wrench } from "lucide-react"
-import ReactMarkdown from "react-markdown"
-import remarkGfm from "remark-gfm"
 
 interface ChatStageReplyProps {
   text: string
-  /** Active tool name shown in a light-yellow badge before the text. */
   toolName?: string
 }
 
 /**
- * Staged (in-progress) reply — grey italic markdown with an optional
- * tool-name badge in light yellow.  Updated in-place as preamble events
- * stream in; replaced by the final ChatTextBlock when the run completes.
+ * Staged reply — one line: optional 🔧 toolName · description.
+ * Grey italic, slightly smaller than body text.  Updated in-place while
+ * the agent runs; replaced by the final ChatTextBlock when done.
  */
 export function ChatStageReply({ text, toolName }: ChatStageReplyProps) {
+  const full = toolName ? `${toolName} · ${text}` : text
+  if (!full) return null
   return (
-    <div className="py-1 text-sm text-muted-foreground/70">
-      {toolName && (
-        <span className="inline-flex items-center gap-1 mr-1.5 rounded bg-yellow-100 dark:bg-yellow-900/30 px-1.5 py-0.5 text-[11px] text-yellow-800 dark:text-yellow-200 font-medium align-middle">
-          <Wrench className="size-2.5" />
-          {toolName}
-        </span>
-      )}
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{text}</ReactMarkdown>
+    <div className="flex items-center gap-1.5 py-1 text-[13px] text-muted-foreground/60 italic leading-relaxed">
+      {toolName && <Wrench className="size-3 shrink-0 opacity-50" />}
+      <span className="truncate">{full}</span>
     </div>
   )
 }

--- a/src/components/chat/chat-stage-reply.tsx
+++ b/src/components/chat/chat-stage-reply.tsx
@@ -1,21 +1,20 @@
 "use client"
 
-import { Loader2 } from "lucide-react"
-
 interface ChatStageReplyProps {
   text: string
 }
 
 /**
- * Staged (in-progress) reply shown during agent execution.
- * Grey italic text + spinning indicator — overwritten by each new
- * stage reply, and replaced by the final reply when the run completes.
+ * Staged (in-progress) reply — grey italic text, updated in-place as
+ * preamble events stream in.  Replaced by the final ChatTextBlock when
+ * the run completes. Handover effect: the store delays clearing the
+ * streaming message by 300ms so the grey text briefly overlaps the
+ * final text appearing in the message history.
  */
 export function ChatStageReply({ text }: ChatStageReplyProps) {
   return (
-    <div className="flex items-center gap-2 py-1">
-      <Loader2 className="size-3 shrink-0 animate-spin text-muted-foreground/60" />
-      <span className="text-sm text-muted-foreground/80">{text}</span>
+    <div className="py-1 text-sm text-muted-foreground/70 italic">
+      {text}
     </div>
   )
 }

--- a/src/components/chat/chat-stage-reply.tsx
+++ b/src/components/chat/chat-stage-reply.tsx
@@ -1,20 +1,22 @@
 "use client"
 
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+
 interface ChatStageReplyProps {
   text: string
 }
 
 /**
- * Staged (in-progress) reply — grey italic text, updated in-place as
- * preamble events stream in.  Replaced by the final ChatTextBlock when
- * the run completes. Handover effect: the store delays clearing the
- * streaming message by 300ms so the grey text briefly overlaps the
- * final text appearing in the message history.
+ * Staged (in-progress) reply — grey italic markdown, updated in-place as
+ * preamble events stream in.  Renders with the same pipeline as ChatTextBlock
+ * so markdown formatting (bold, code, lists) appears in real-time, not just
+ * at the end.
  */
 export function ChatStageReply({ text }: ChatStageReplyProps) {
   return (
-    <div className="py-1 text-sm text-muted-foreground/70 italic">
-      {text}
+    <div className="py-1 text-sm text-muted-foreground/70">
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{text}</ReactMarkdown>
     </div>
   )
 }

--- a/src/components/chat/chat-text-block.tsx
+++ b/src/components/chat/chat-text-block.tsx
@@ -54,26 +54,6 @@ export const ChatTextBlock = memo(function ChatTextBlock({
         urlTransform={(url) => url}
         components={{
           // Rewrite output/ links to session file download API
-          a({ href, children, ...props }) {
-            const h = String(href ?? '')
-            if (h.startsWith('output/') && activeSessionId) {
-              const apiUrl = `/api/v1/chat/sessions/${activeSessionId}/files/${h}`
-              return (
-                <a
-                  href={apiUrl}
-                  download
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 text-primary underline hover:no-underline"
-                  {...props}
-                >
-                  <Download className="size-3" />
-                  {children}
-                </a>
-              )
-            }
-            return <a href={h} target="_blank" rel="noopener noreferrer" {...props}>{children}</a>
-          },
           // --- Code blocks ---
           pre({ children }) {
             return <div className="my-2">{children}</div>
@@ -138,6 +118,18 @@ export const ChatTextBlock = memo(function ChatTextBlock({
           },
           // --- Links ---
           a({ href, children }) {
+            // Agent output files: rewrite output/ links to session download API
+            if (typeof href === 'string' && href.startsWith('output/') && activeSessionId) {
+              const apiUrl = `/api/v1/chat/sessions/${activeSessionId}/files/${href}`
+              return (
+                <a href={apiUrl} download target="_blank" rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400 underline decoration-blue-600/30 dark:decoration-blue-400/30 hover:decoration-blue-600 dark:hover:decoration-blue-400 cursor-pointer"
+                >
+                  <Download className="size-3" />
+                  {children}
+                </a>
+              )
+            }
             const intercepted = !!href && !!shouldIntercept?.(href)
             return (
               <a

--- a/src/components/chat/chat-text-block.tsx
+++ b/src/components/chat/chat-text-block.tsx
@@ -4,8 +4,9 @@ import { memo } from 'react'
 import dynamic from 'next/dynamic'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
-import { Loader2 } from 'lucide-react'
+import { Download, Loader2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { useChatStore } from '@/stores/chat-store'
 
 function ChartLoadingSkeleton() {
   return (
@@ -44,17 +45,35 @@ export const ChatTextBlock = memo(function ChatTextBlock({
   // LLMs occasionally emit raw HTML <br> inside markdown cells.
   // ReactMarkdown strips HTML for safety — turn <br> into actual
   // newlines so bullets and table cells render correctly.
+  const activeSessionId = useChatStore((s) => s.activeSessionId)
   const cleaned = content.replace(/<br\s*\/?>/gi, '\n')
   return (
     <div className="text-sm leading-relaxed prose-chat overflow-x-auto min-w-0">
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
-        // react-markdown strips href values whose URL scheme isn't in the
-        // safe-list (http/https/mailto/tel) by default. We use custom
-        // schemes like `kb-page:` for page-citation chips that get
-        // intercepted in JS — let those through without rewriting.
         urlTransform={(url) => url}
         components={{
+          // Rewrite output/ links to session file download API
+          a({ href, children, ...props }) {
+            const h = String(href ?? '')
+            if (h.startsWith('output/') && activeSessionId) {
+              const apiUrl = `/api/v1/chat/sessions/${activeSessionId}/files/${h}`
+              return (
+                <a
+                  href={apiUrl}
+                  download
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-primary underline hover:no-underline"
+                  {...props}
+                >
+                  <Download className="size-3" />
+                  {children}
+                </a>
+              )
+            }
+            return <a href={h} target="_blank" rel="noopener noreferrer" {...props}>{children}</a>
+          },
           // --- Code blocks ---
           pre({ children }) {
             return <div className="my-2">{children}</div>

--- a/src/lib/chat/chat-display.test.ts
+++ b/src/lib/chat/chat-display.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { selectChatDisplay } from './chat-display'
+
+describe('v4 chat display selection (thinking hidden / staged overwrite / final replace)', () => {
+  it('shows the latest staged text while the run is in progress', () => {
+    const d = selectChatDisplay([
+      {
+        text: '正在查看目录',
+        toolCalls: [{ toolName: 'exec', toolInput: { command: 'ls' } }],
+        isFinal: false,
+      },
+    ])
+    expect(d.stagedText).toBe('正在查看目录')
+    expect(d.finalText).toBe(null)
+    expect(d.toolCalls).toEqual([{ toolName: 'exec', toolInput: { command: 'ls' } }])
+  })
+
+  it('replaces staged with final text when the final turn arrives', () => {
+    const d = selectChatDisplay([
+      {
+        text: '正在查看目录',
+        toolCalls: [{ toolName: 'exec', toolInput: { command: 'ls' } }],
+        isFinal: false,
+      },
+      { text: '当前目录下有 6 个文件', isFinal: true },
+    ])
+    expect(d.finalText).toBe('当前目录下有 6 个文件')
+    expect(d.stagedText).toBe(null)
+    expect(d.toolCalls).toEqual([{ toolName: 'exec', toolInput: { command: 'ls' } }])
+  })
+
+  it('keeps only the latest staged text and merges all tool calls', () => {
+    const d = selectChatDisplay([
+      { text: '先看目录', toolCalls: [{ toolName: 'exec', toolInput: { command: 'ls' } }], isFinal: false },
+      { text: '再读文件', toolCalls: [{ toolName: 'exec', toolInput: { command: 'cat x' } }], isFinal: false },
+    ])
+    expect(d.stagedText).toBe('再读文件')
+    expect(d.toolCalls).toHaveLength(2)
+  })
+})

--- a/src/lib/chat/chat-display.ts
+++ b/src/lib/chat/chat-display.ts
@@ -1,0 +1,34 @@
+/**
+ * Select what to render for a v4 chat turn group, per issue #13:
+ *   - thinking: dropped (never rendered)
+ *   - tool calls: kept (all turns merged)
+ *   - staged reply: only the LATEST non-final turn's text (overwrite, not accrue)
+ *   - final reply: the final turn's text, which replaces the staged area
+ *
+ * Pure function over already-parsed turns (see parseSessionMessage). Drives the
+ * chat-assistant-message render without it owning the staged/final logic.
+ */
+export interface DisplayTurn {
+  text: string
+  toolCalls?: { toolName: string; toolInput: unknown }[]
+  isFinal: boolean
+}
+
+export interface ChatDisplay {
+  toolCalls: { toolName: string; toolInput: unknown }[]
+  /** Latest in-progress reply (null once the final reply exists). */
+  stagedText: string | null
+  /** Final reply text (null while still running). */
+  finalText: string | null
+}
+
+export function selectChatDisplay(turns: DisplayTurn[]): ChatDisplay {
+  const toolCalls = turns.flatMap((t) => t.toolCalls ?? [])
+  const final = turns.find((t) => t.isFinal)
+  const staged = [...turns].reverse().find((t) => !t.isFinal && t.text)
+  return {
+    toolCalls,
+    stagedText: final ? null : (staged?.text ?? null),
+    finalText: final?.text ?? null,
+  }
+}

--- a/src/lib/chat/image-blocks.test.ts
+++ b/src/lib/chat/image-blocks.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { imageBlockDisplayKey, imageIdFromHistoryUrl, uniqueImageBlocks } from './image-blocks'
+
+describe('chat image block display keys', () => {
+  it('extracts image ids from history image URLs', () => {
+    expect(
+      imageIdFromHistoryUrl('/api/v1/chat/sessions/session-1/images/abc123?size=small'),
+    ).toBe('abc123')
+  })
+
+  it('deduplicates an imageId block and a matching history URL block', () => {
+    const blocks = uniqueImageBlocks([
+      {
+        type: 'image',
+        imageId: 'abc123',
+        imageUrl: 'data:image/png;base64,old-inline',
+      },
+      {
+        type: 'image',
+        imageUrl: '/api/v1/chat/sessions/session-1/images/abc123',
+      },
+    ])
+
+    expect(blocks).toHaveLength(1)
+    expect(imageBlockDisplayKey(blocks[0])).toBe('image:abc123')
+  })
+})

--- a/src/lib/chat/image-blocks.ts
+++ b/src/lib/chat/image-blocks.ts
@@ -1,0 +1,43 @@
+import type { ChatContentBlock } from '@/types/chat'
+
+const HISTORY_IMAGE_RE = /\/api\/v1\/chat\/sessions\/[^/?#]+\/images\/([^/?#]+)/
+
+export function imageIdFromHistoryUrl(imageUrl: string | undefined): string | null {
+  if (!imageUrl) return null
+
+  const match = imageUrl.match(HISTORY_IMAGE_RE)
+  if (!match?.[1]) return null
+
+  try {
+    return decodeURIComponent(match[1])
+  } catch {
+    return match[1]
+  }
+}
+
+export function imageBlockDisplayKey(block: ChatContentBlock): string {
+  if (block.type !== 'image') return `content:${block.type}:${block.text ?? ''}`
+
+  const urlImageId = imageIdFromHistoryUrl(block.imageUrl)
+  const imageId = urlImageId ?? block.imageId
+  return imageId ? `image:${imageId}` : `image-url:${block.imageUrl ?? ''}`
+}
+
+export function uniqueImageBlocks(
+  blocks: ChatContentBlock[] | undefined,
+): ChatContentBlock[] {
+  const seen = new Set<string>()
+  const unique: ChatContentBlock[] = []
+
+  for (const block of blocks ?? []) {
+    if (block.type !== 'image' || !block.imageUrl) continue
+
+    const key = imageBlockDisplayKey(block)
+    if (seen.has(key)) continue
+
+    unique.push(block)
+    seen.add(key)
+  }
+
+  return unique
+}

--- a/src/lib/chat/session-message.test.ts
+++ b/src/lib/chat/session-message.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { parseSessionMessage } from './session-message'
+
+describe('v4 session.message parsing', () => {
+  it('parses a final assistant message (stopReason=stop) into text + thinking', () => {
+    const parsed = parseSessionMessage({
+      messageId: 'a4b4ff6e',
+      messageSeq: 4,
+      message: {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'reasoning here' },
+          { type: 'text', text: '当前目录下有 6 个文件' },
+        ],
+        stopReason: 'stop',
+      },
+    })
+    expect(parsed.role).toBe('assistant')
+    expect(parsed.text).toBe('当前目录下有 6 个文件')
+    expect(parsed.thinking).toBe('reasoning here')
+    expect(parsed.isFinal).toBe(true)
+  })
+
+  it('parses a staged assistant message (stopReason=toolUse) with tool calls', () => {
+    const parsed = parseSessionMessage({
+      messageId: '68a3e251',
+      messageSeq: 2,
+      message: {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'let me run ls' },
+          { type: 'toolCall', id: 'call_x', name: 'exec', arguments: { command: 'ls' } },
+        ],
+        stopReason: 'toolUse',
+      },
+    })
+    expect(parsed.isFinal).toBe(false)
+    expect(parsed.stopReason).toBe('toolUse')
+    expect(parsed.toolCalls).toEqual([{ toolName: 'exec', toolInput: { command: 'ls' } }])
+  })
+
+  it('parses a user message with plain string content', () => {
+    const parsed = parseSessionMessage({
+      messageId: 'cf6bb550',
+      messageSeq: 1,
+      message: { role: 'user', content: '用 exec 工具执行 ls' },
+    })
+    expect(parsed.role).toBe('user')
+    expect(parsed.text).toBe('用 exec 工具执行 ls')
+    expect(parsed.isFinal).toBe(false)
+  })
+})

--- a/src/lib/chat/session-message.ts
+++ b/src/lib/chat/session-message.ts
@@ -1,0 +1,62 @@
+/**
+ * Parse a v4 `session.message` event into the fields TeamClaw's chat UI needs.
+ *
+ * v4 session.message carries the full assistant/user turn as content blocks
+ * (`thinking` | `toolCall` | `text`) plus `stopReason`. `stopReason==='stop'`
+ * marks the final turn; `'toolUse'` marks an intermediate (staged) turn. This
+ * is more authoritative than the legacy "has toolCalls?" heuristic and drives
+ * the issue #13 staged/final display.
+ */
+export interface ParsedSessionMessage {
+  messageId: string
+  messageSeq: number
+  role: 'user' | 'assistant'
+  text: string
+  thinking?: string
+  toolCalls?: { toolName: string; toolInput: unknown }[]
+  stopReason?: string
+  /** True when this is the model's final turn (stopReason==='stop'). */
+  isFinal: boolean
+}
+
+interface RawBlock {
+  type?: string
+  text?: string
+  thinking?: string
+  name?: string
+  arguments?: unknown
+}
+
+export function parseSessionMessage(event: unknown): ParsedSessionMessage {
+  const e = (event ?? {}) as Record<string, unknown>
+  const msg = (e.message ?? {}) as Record<string, unknown>
+  const role = msg.role === 'user' ? 'user' : 'assistant'
+  const rawContent = msg.content
+  const blocks: RawBlock[] = Array.isArray(rawContent) ? (rawContent as RawBlock[]) : []
+
+  const text =
+    typeof rawContent === 'string'
+      ? rawContent
+      : blocks
+          .filter((b) => b.type === 'text')
+          .map((b) => b.text ?? '')
+          .join('')
+  const thinkingParts = blocks.filter((b) => b.type === 'thinking').map((b) => b.thinking ?? '')
+  const thinking = thinkingParts.length ? thinkingParts.join('\n') : undefined
+  const toolCallBlocks = blocks.filter((b) => b.type === 'toolCall')
+  const toolCalls = toolCallBlocks.length
+    ? toolCallBlocks.map((b) => ({ toolName: b.name ?? 'tool', toolInput: b.arguments }))
+    : undefined
+  const stopReason = typeof msg.stopReason === 'string' ? msg.stopReason : undefined
+
+  return {
+    messageId: String(e.messageId ?? ''),
+    messageSeq: typeof e.messageSeq === 'number' ? e.messageSeq : 0,
+    role,
+    text,
+    ...(thinking ? { thinking } : {}),
+    ...(toolCalls ? { toolCalls } : {}),
+    ...(stopReason ? { stopReason } : {}),
+    isFinal: stopReason === 'stop',
+  }
+}

--- a/src/lib/chat/snapshot-helpers.test.ts
+++ b/src/lib/chat/snapshot-helpers.test.ts
@@ -31,6 +31,7 @@ vi.mock('@/lib/db', () => ({
 }))
 
 vi.mock('@/lib/chat/image-helpers', () => ({
+  computeImageId: vi.fn((dataUrl: string) => `hash:${dataUrl}`),
   extractMediaPaths: vi.fn(() => []),
   readImageAsDataUrl: vi.fn(),
   readContainerImageAsDataUrl: vi.fn(),
@@ -43,6 +44,7 @@ import {
   archiveSession,
   MAX_LIVE_MESSAGES,
   mergeLiveMessagesAppendOnly,
+  mergeToolCalls,
   saveLiveSnapshot,
   shouldUseLiveMessagesFallback,
 } from './snapshot-helpers'
@@ -63,6 +65,16 @@ function chatMessage(
 
 function user(content: string): ChatHistoryMessage {
   return { role: 'user', content }
+}
+
+function userWithImage(content: string, mimeType: string, data: string): ChatHistoryMessage {
+  return {
+    role: 'user',
+    content: [
+      { type: 'text', text: content },
+      { type: 'image', source: { type: 'base64', media_type: mimeType, data } },
+    ],
+  }
 }
 
 function assistant(content: string): ChatHistoryMessage {
@@ -183,6 +195,41 @@ describe('live snapshot append-only merge', () => {
     )
   })
 
+  it('does not duplicate uploaded image attachments already present in history', async () => {
+    const imageData = 'same-image'
+    const client = {
+      request: vi.fn().mockResolvedValue({
+        sessionId: 'gw-1',
+        messages: [
+          userWithImage('see this', 'image/png', imageData),
+          assistant('ok'),
+        ],
+      }),
+    }
+
+    mocks.prisma.chatSession.findUnique.mockResolvedValue({
+      gwSessionId: 'gw-1',
+      liveMessages: [],
+    })
+
+    await saveLiveSnapshot(
+      'chat-1',
+      client as never,
+      'agent:a:tc:u',
+      null,
+      undefined,
+      [{ name: 'image.png', mimeType: 'image/png', content: imageData }],
+    )
+
+    const updateArg = mocks.prisma.chatSession.update.mock.calls[0][0]
+    const liveMessages = updateArg.data.liveMessages as ChatMessage[]
+
+    expect(liveMessages[0].contentBlocks).toHaveLength(1)
+    expect(liveMessages[0].contentBlocks?.[0].imageUrl).toBe(
+      'data:image/png;base64,same-image',
+    )
+  })
+
   it('archives sessions with the unified 500 history limit', async () => {
     const client = {
       request: vi.fn()
@@ -252,5 +299,28 @@ describe('live snapshot append-only merge', () => {
     expect(updateArg.data.liveMessages).toHaveLength(MAX_LIVE_MESSAGES)
     expect(updateArg.data.liveMessages[0].content).toBe('message-2')
     expect(updateArg.data.liveMessages.at(-1).content).toBe('new reply')
+  })
+})
+
+describe('mergeToolCalls', () => {
+  it('drops stale tool calls from old messages when the new message has fewer', () => {
+    const result = mergeToolCalls(
+      [{ toolName: 'bash', toolInput: 'ls', toolOutput: 'AGENTS.md' }],
+      undefined,
+    )
+    expect(result).toBeUndefined()
+  })
+
+  it('drops extra old tool calls beyond the new count', () => {
+    const result = mergeToolCalls(
+      [
+        { toolName: 'exec', toolInput: 'ls', toolOutput: 'ok' },
+        { toolName: 'read', toolInput: 'x.md', toolOutput: '...' },
+      ],
+      [{ toolName: 'exec', toolInput: null, toolOutput: 'ok' }],
+    )
+    expect(result).toHaveLength(1)
+    expect(result![0].toolName).toBe('exec')
+    expect(result![0].toolInput).toBe('ls') // preserves old enriched input
   })
 })

--- a/src/lib/chat/snapshot-helpers.test.ts
+++ b/src/lib/chat/snapshot-helpers.test.ts
@@ -323,4 +323,13 @@ describe('mergeToolCalls', () => {
     expect(result![0].toolName).toBe('exec')
     expect(result![0].toolInput).toBe('ls') // preserves old enriched input
   })
+
+  it('prefers new gateway toolName over stale old data', () => {
+    const result = mergeToolCalls(
+      [{ toolName: 'bash', toolInput: null, toolOutput: '' }],
+      [{ toolName: 'exec', toolInput: null, toolOutput: 'ok' }],
+    )
+    expect(result![0].toolName).toBe('exec')
+    expect(result![0].toolOutput).toBe('ok')
+  })
 })

--- a/src/lib/chat/snapshot-helpers.ts
+++ b/src/lib/chat/snapshot-helpers.ts
@@ -531,9 +531,10 @@ export function mergeToolCalls(
 
     if (oldCall && newCall) {
       merged.push({
-        toolName: oldCall.toolName || newCall.toolName,
+        // Prefer new gateway data (authoritative); old enriches with SSE-captured inputs
+        toolName: newCall.toolName || oldCall.toolName,
         toolInput: hasValue(oldCall.toolInput) ? oldCall.toolInput : newCall.toolInput,
-        toolOutput: hasValue(oldCall.toolOutput) ? oldCall.toolOutput : newCall.toolOutput,
+        toolOutput: hasValue(newCall.toolOutput) ? newCall.toolOutput : oldCall.toolOutput,
       })
     } else if (newCall) {
       merged.push({ ...newCall })

--- a/src/lib/chat/snapshot-helpers.ts
+++ b/src/lib/chat/snapshot-helpers.ts
@@ -3,12 +3,14 @@ import { extname } from 'path'
 import { Prisma } from '@/generated/prisma'
 import { prisma } from '@/lib/db'
 import {
+  computeImageId,
   extractMediaPaths,
   readImageAsDataUrl,
   readContainerImageAsDataUrl,
   stampImageIds,
   MIME_BY_EXT,
 } from '@/lib/chat/image-helpers'
+import { imageIdFromHistoryUrl } from '@/lib/chat/image-blocks'
 import { stripRagContextForDisplay } from '@/lib/chat/rag-user-message'
 import type { ChatHistoryMessage, ChatHistoryResult } from '@/types/gateway'
 import type { ChatToolCall, ChatContentBlock, ChatMessage } from '@/types/chat'
@@ -78,7 +80,7 @@ export function extractContentBlocks(content: ChatHistoryMessage['content']): Ch
       }
     }
   }
-  return blocks.length > 0 ? blocks : undefined
+  return dedupeContentBlocks(blocks)
 }
 
 /**
@@ -455,15 +457,49 @@ function findIncomingOverlap(
 }
 
 function contentBlockKey(block: ChatContentBlock): string {
-  if (block.type === 'image') return `image:${block.imageId ?? block.imageUrl ?? ''}`
+  if (block.type === 'image') {
+    const urlImageId = imageIdFromHistoryUrl(block.imageUrl)
+    const imageId =
+      urlImageId ??
+      block.imageId ??
+      (block.imageUrl?.startsWith('data:') ? computeImageId(block.imageUrl) : undefined)
+    return imageId ? `image:${imageId}` : `image-url:${block.imageUrl ?? ''}`
+  }
   return `text:${block.text ?? ''}`
+}
+
+function dedupeContentBlocks(
+  blocks: ChatContentBlock[] | undefined,
+): ChatContentBlock[] | undefined {
+  const unique: ChatContentBlock[] = []
+  const seen = new Set<string>()
+
+  for (const block of blocks ?? []) {
+    const key = contentBlockKey(block)
+    if (seen.has(key)) continue
+    unique.push({ ...block })
+    seen.add(key)
+  }
+
+  return unique.length > 0 ? unique : undefined
+}
+
+function dedupeMessageContentBlocks(messages: ChatMessage[]): void {
+  for (const message of messages) {
+    const contentBlocks = dedupeContentBlocks(message.contentBlocks)
+    if (contentBlocks) {
+      message.contentBlocks = contentBlocks
+    } else {
+      delete message.contentBlocks
+    }
+  }
 }
 
 function mergeContentBlocks(
   oldBlocks: ChatContentBlock[] | undefined,
   newBlocks: ChatContentBlock[] | undefined,
 ): ChatContentBlock[] | undefined {
-  const merged = cloneContentBlocks(oldBlocks) ?? []
+  const merged = dedupeContentBlocks(oldBlocks) ?? []
   const seen = new Set(merged.map(contentBlockKey))
 
   for (const block of newBlocks ?? []) {
@@ -480,7 +516,7 @@ function hasValue(value: unknown): boolean {
   return value != null && value !== ''
 }
 
-function mergeToolCalls(
+export function mergeToolCalls(
   oldToolCalls: ChatToolCall[] | undefined,
   newToolCalls: ChatToolCall[] | undefined,
 ): ChatToolCall[] | undefined {
@@ -499,11 +535,13 @@ function mergeToolCalls(
         toolInput: hasValue(oldCall.toolInput) ? oldCall.toolInput : newCall.toolInput,
         toolOutput: hasValue(oldCall.toolOutput) ? oldCall.toolOutput : newCall.toolOutput,
       })
-    } else if (oldCall) {
-      merged.push({ ...oldCall })
     } else if (newCall) {
       merged.push({ ...newCall })
     }
+    // Drop stale tool calls that exist only in the old message (no matching
+    // new call from the gateway). Without this, tool calls leak from old
+    // messages into new messages during gwSessionId-changed resets, and the
+    // stale entries compound across successive merge cycles.
   }
 
   return merged.length > 0 ? merged : undefined
@@ -661,14 +699,19 @@ export async function saveLiveSnapshot(
   if (userAttachments?.length) {
     for (let i = liveMessages.length - 1; i >= 0; i--) {
       if (liveMessages[i].role === 'user') {
-        const blocks: ChatContentBlock[] = liveMessages[i].contentBlocks ?? []
+        const blocks: ChatContentBlock[] = dedupeContentBlocks(liveMessages[i].contentBlocks) ?? []
+        const seen = new Set(blocks.map(contentBlockKey))
         for (const att of userAttachments) {
           if (!att.mimeType.startsWith('image/')) continue
-          blocks.push({
+          const block: ChatContentBlock = {
             type: 'image',
             imageUrl: `data:${att.mimeType};base64,${att.content}`,
             mimeType: att.mimeType,
-          })
+          }
+          const key = contentBlockKey(block)
+          if (seen.has(key)) continue
+          blocks.push(block)
+          seen.add(key)
         }
         if (blocks.length > 0) liveMessages[i].contentBlocks = blocks
         break
@@ -901,6 +944,9 @@ async function writeLiveMessages(
   gwSessionId: string | undefined,
   archiveMessages: ChatMessage[],
 ): Promise<void> {
+  dedupeMessageContentBlocks(liveMessages)
+  dedupeMessageContentBlocks(archiveMessages)
+
   // Pre-compute imageId on all image blocks so the image endpoint
   // can look up by field match instead of re-hashing on every request.
   stampImageIds(liveMessages)
@@ -939,6 +985,7 @@ export async function appendLiveMessages(
       ? (session.liveMessages as unknown as ChatMessage[])
       : []
     const liveMessages = [...existingLive.map(cloneMessage), ...messages.map(cloneMessage)]
+    dedupeMessageContentBlocks(liveMessages)
     stampImageIds(liveMessages)
     await prisma.chatSession.update({
       where: { id: chatSessionId },

--- a/src/lib/chat/stream-delta.test.ts
+++ b/src/lib/chat/stream-delta.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { computeTextDelta } from './stream-delta'
+
+describe('v4 chat text delta (computeTextDelta)', () => {
+  it('emits deltaText directly without slicing the cumulative snapshot', () => {
+    const out = computeTextDelta({
+      deltaText: ' world',
+      cumulative: 'hello world',
+      lastEmitted: 'hello',
+    })
+    expect(out.text).toBe(' world')
+    expect(out.replace).toBe(false)
+    expect(out.nextLast).toBe('hello world')
+  })
+
+  it('marks a non-prefix replacement so the frontend replaces instead of appends', () => {
+    const out = computeTextDelta({
+      deltaText: 'corrected answer',
+      replace: true,
+      cumulative: 'corrected answer',
+      lastEmitted: 'wrong draft',
+    })
+    expect(out.text).toBe('corrected answer')
+    expect(out.replace).toBe(true)
+    expect(out.nextLast).toBe('corrected answer')
+  })
+
+  it('falls back to slicing the cumulative snapshot when deltaText is absent', () => {
+    const out = computeTextDelta({
+      cumulative: 'hello world',
+      lastEmitted: 'hello',
+    })
+    expect(out.text).toBe(' world')
+    expect(out.replace).toBe(false)
+    expect(out.nextLast).toBe('hello world')
+  })
+})

--- a/src/lib/chat/stream-delta.test.ts
+++ b/src/lib/chat/stream-delta.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, it } from 'vitest'
 import { computeTextDelta } from './stream-delta'
 
 describe('v4 chat text delta (computeTextDelta)', () => {
-  it('emits deltaText directly without slicing the cumulative snapshot', () => {
+  it('prefers cumulative slice over deltaText when already partially emitted', () => {
     const out = computeTextDelta({
-      deltaText: ' world',
+      deltaText: 'hello world',
       cumulative: 'hello world',
       lastEmitted: 'hello',
     })
-    expect(out.text).toBe(' world')
+    expect(out.text).toBe(' world')  // sliced, not full deltaText
     expect(out.replace).toBe(false)
     expect(out.nextLast).toBe('hello world')
   })
@@ -25,13 +25,13 @@ describe('v4 chat text delta (computeTextDelta)', () => {
     expect(out.nextLast).toBe('corrected answer')
   })
 
-  it('falls back to slicing the cumulative snapshot when deltaText is absent', () => {
+  it('uses deltaText when cumulative has not advanced', () => {
     const out = computeTextDelta({
-      cumulative: 'hello world',
+      deltaText: 'extra',
+      cumulative: 'hello',
       lastEmitted: 'hello',
     })
-    expect(out.text).toBe(' world')
-    expect(out.replace).toBe(false)
-    expect(out.nextLast).toBe('hello world')
+    expect(out.text).toBe('extra')  // sliced = '', deltaText is the only increment
+    expect(out.nextLast).toBe('hello')
   })
 })

--- a/src/lib/chat/stream-delta.ts
+++ b/src/lib/chat/stream-delta.ts
@@ -1,0 +1,44 @@
+/**
+ * Compute what text to emit to the SSE stream for one v4 chat `delta` event.
+ *
+ * v4 chat deltas carry `deltaText` (the increment) alongside `message` (the
+ * cumulative assistant snapshot). Non-prefix replacements set `replace=true`
+ * and use `deltaText` as the replacement text. This pure function centralizes
+ * that contract so the SSE route stays thin and the logic is unit-testable.
+ */
+export interface DeltaInput {
+  /** v4 increment; absent on legacy/edge events. */
+  deltaText?: string
+  /** v4 non-prefix replacement flag. */
+  replace?: boolean
+  /** Cumulative assistant text snapshot (extractTextFromMessage(evt.message)). */
+  cumulative: string
+  /** Cumulative text emitted so far (for the no-deltaText fallback). */
+  lastEmitted: string
+}
+
+export interface DeltaOutput {
+  /** Text to write to the stream (empty string = nothing to emit). */
+  text: string
+  /** Whether the frontend should replace the rendered text instead of appending. */
+  replace: boolean
+  /** New cumulative-emitted value to carry into the next event. */
+  nextLast: string
+}
+
+export function computeTextDelta(input: DeltaInput): DeltaOutput {
+  if (typeof input.deltaText === 'string') {
+    return {
+      text: input.deltaText,
+      replace: input.replace === true,
+      nextLast: input.cumulative,
+    }
+  }
+  // Fallback (no deltaText): slice the cumulative snapshot. Defensive — v4
+  // always carries deltaText, but legacy/edge events may not.
+  return {
+    text: input.cumulative.slice(input.lastEmitted.length),
+    replace: false,
+    nextLast: input.cumulative,
+  }
+}

--- a/src/lib/chat/stream-delta.ts
+++ b/src/lib/chat/stream-delta.ts
@@ -27,18 +27,28 @@ export interface DeltaOutput {
 }
 
 export function computeTextDelta(input: DeltaInput): DeltaOutput {
-  if (typeof input.deltaText === 'string') {
+  // Non-prefix replacement: use deltaText as the authoritative replacement.
+  if (input.replace) {
     return {
-      text: input.deltaText,
-      replace: input.replace === true,
+      text: input.deltaText ?? '',
+      replace: true,
       nextLast: input.cumulative,
     }
   }
-  // Fallback (no deltaText): slice the cumulative snapshot. Defensive — v4
-  // always carries deltaText, but legacy/edge events may not.
-  return {
-    text: input.cumulative.slice(input.lastEmitted.length),
-    replace: false,
-    nextLast: input.cumulative,
+  // When we already have partial text (e.g. from agent item preamble events),
+  // slice the cumulative remainder instead of emitting the full deltaText.
+  const sliced = input.cumulative.slice(input.lastEmitted.length)
+  if (sliced) {
+    return { text: sliced, replace: false, nextLast: input.cumulative }
   }
+  // No new cumulative text.  v4 deltaText may still carry an increment — use
+  // it directly, but only when we haven't already seen this content.
+  if (typeof input.deltaText === 'string') {
+    return {
+      text: input.deltaText,
+      replace: false,
+      nextLast: input.cumulative,
+    }
+  }
+  return { text: '', replace: false, nextLast: input.cumulative }
 }

--- a/src/lib/gateway/client.test.ts
+++ b/src/lib/gateway/client.test.ts
@@ -13,11 +13,10 @@ describe('gateway connect handshake', () => {
     expect(params.role).toBe('operator')
   })
 
-  // Regression lock: this is the exact connection posture the v4 spike proved
-  // can authenticate against the 6.6 gateway (control-ui backend client on the
-  // dangerouslyDisableDeviceAuth trust path). Changing any of these silently
-  // breaks the handshake, so pin them.
-  it('preserves the connection posture verified by the v4 spike', () => {
+  // Regression lock: the control-ui backend client + scopes below are the
+  // exact handshake that authenticates against the v4 gateway.  Changing
+  // any of these fields silently breaks the connect — keep them pinned.
+  it('preserves the v4 handshake posture required by the gateway', () => {
     const params = buildConnectParams('tok-xyz')
     expect(params.client.id).toBe('openclaw-control-ui')
     expect(params.client.mode).toBe('backend')

--- a/src/lib/gateway/client.test.ts
+++ b/src/lib/gateway/client.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { buildConnectParams } from './client'
+
+describe('gateway connect handshake', () => {
+  it('negotiates protocol v4', () => {
+    const params = buildConnectParams('tok-123')
+    expect(params.minProtocol).toBe(4)
+    expect(params.maxProtocol).toBe(4)
+  })
+
+  it('declares the operator role required by the v4 handshake', () => {
+    const params = buildConnectParams('tok-123')
+    expect(params.role).toBe('operator')
+  })
+
+  // Regression lock: this is the exact connection posture the v4 spike proved
+  // can authenticate against the 6.6 gateway (control-ui backend client on the
+  // dangerouslyDisableDeviceAuth trust path). Changing any of these silently
+  // breaks the handshake, so pin them.
+  it('preserves the connection posture verified by the v4 spike', () => {
+    const params = buildConnectParams('tok-xyz')
+    expect(params.client.id).toBe('openclaw-control-ui')
+    expect(params.client.mode).toBe('backend')
+    expect(params.scopes).toEqual(['operator.read', 'operator.write', 'operator.admin'])
+    expect(params.auth.token).toBe('tok-xyz')
+  })
+})

--- a/src/lib/gateway/client.ts
+++ b/src/lib/gateway/client.ts
@@ -6,7 +6,10 @@ import type {
   GatewayEvent,
 } from '@/types/gateway'
 
-const PROTOCOL_VERSION = 3
+// v4: OpenClaw 6.6 gateway requires protocol v4 (MIN_CLIENT_PROTOCOL_VERSION=4);
+// v3 clients are rejected with close code 1002. All connected instances must be
+// on OpenClaw 6.6 (sales container upgrade is the prerequisite — see issue #7).
+const PROTOCOL_VERSION = 4
 // 120s default: first-chat system-prompt generation takes ~60s, plus
 // provider-plugin pnpm staging can block the event loop for ~20s.
 const REQUEST_TIMEOUT_MS = 120_000
@@ -21,6 +24,28 @@ interface PendingRequest {
 }
 
 type EventCallback = (payload: unknown) => void
+
+/**
+ * Build the connect-handshake params. Kept as a pure function so the protocol
+ * contract (version negotiation, client identity, scopes) is unit-testable
+ * without opening a socket.
+ */
+export function buildConnectParams(token: string) {
+  return {
+    minProtocol: PROTOCOL_VERSION,
+    maxProtocol: PROTOCOL_VERSION,
+    client: {
+      id: 'openclaw-control-ui' as const,
+      version: '1.0.0',
+      platform: typeof process !== 'undefined' ? process.platform : 'unknown',
+      mode: 'backend' as const,
+    },
+    role: 'operator' as const,
+    auth: { token },
+    scopes: ['operator.read', 'operator.write', 'operator.admin'],
+    caps: [],
+  }
+}
 
 export class GatewayClient {
   private ws: WebSocket | null = null
@@ -256,19 +281,7 @@ export class GatewayClient {
 
   /** Send the connect request with protocol negotiation + auth. */
   private sendConnect(): void {
-    const params = {
-      minProtocol: PROTOCOL_VERSION,
-      maxProtocol: PROTOCOL_VERSION,
-      client: {
-        id: 'openclaw-control-ui' as const,
-        version: '1.0.0',
-        platform: typeof process !== 'undefined' ? process.platform : 'unknown',
-        mode: 'backend' as const,
-      },
-      auth: { token: this.token },
-      scopes: ['operator.read', 'operator.write', 'operator.admin'],
-      caps: [],
-    }
+    const params = buildConnectParams(this.token)
 
     this.request('connect', params as unknown as Record<string, unknown>)
       .then((helloOk) => {

--- a/src/lib/gateway/client.ts
+++ b/src/lib/gateway/client.ts
@@ -37,7 +37,7 @@ export function buildConnectParams(token: string) {
     client: {
       id: 'openclaw-control-ui' as const,
       version: '1.0.0',
-      platform: typeof process !== 'undefined' ? process.platform : 'unknown',
+      platform: 'node',
       mode: 'backend' as const,
     },
     role: 'operator' as const,
@@ -111,11 +111,10 @@ export class GatewayClient {
       const httpUrl = this.url.replace(/^ws(s?):/, 'http$1:')
       const loopbackUrl = httpUrl.replace('host.docker.internal', '127.0.0.1')
       const headers: Record<string, string> = { Origin: loopbackUrl }
-      if (this.url.includes('host.docker.internal')) {
-        const parsed = new URL(loopbackUrl)
-        headers['Host'] = parsed.host
-      }
-      this.ws = new WebSocket(this.url, { headers })
+      // Force IPv4 — host.docker.internal resolves to both v4 and v6, and
+      // the gateway may apply different event-streaming policies per address
+      // family. Explicit v4 matches the direct spike behaviour.
+      this.ws = new WebSocket(this.url, { headers, family: 4 })
 
       this.ws.on('message', (data: WebSocket.Data) => {
         this.handleMessage(data)
@@ -155,6 +154,28 @@ export class GatewayClient {
         }
       })
     })
+  }
+
+  /**
+   * Force a fresh connection. The persistent GatewayClient socket receives
+   * compressed event streams from the v4 gateway (single full-text delta +
+   * no agent:item tool events); a fresh connect gets full incremental
+   * streaming. Call before chat.send when tool events and streaming matter.
+   */
+  async reconnect(): Promise<void> {
+    this.intentionalDisconnect = true
+    this.clearConnectTimer()
+    this.stopTickWatch()
+    this.clearReconnectTimer()
+    this.rejectAllPending('Client reconnecting')
+    if (this.ws) {
+      this.ws.close()
+      this.ws = null
+    }
+    this.connected = false
+    // Brief delay to avoid gateway connection-throttle detection
+    await new Promise((r) => setTimeout(r, 500))
+    return this.connect()
   }
 
   /** Cleanly shut down the connection. */

--- a/src/stores/chat-store.ts
+++ b/src/stores/chat-store.ts
@@ -588,9 +588,11 @@ export const useChatStore = create<ChatState>((set, get) => ({
       const finalStreaming = get().streamingMessage
       const finalKbSources = finalStreaming?.kbSources ?? []
       if (historySynced) {
+        // Clear streamingMessage FIRST so the stage reply unmounts before
+        // history ChatTextBlock renders — prevents two copies appearing.
+        set({ streamingMessage: null })
         set((s) => ({
           messages: attachKbSourcesToLatestAssistant(s.messages, finalKbSources),
-          streamingMessage: null,
           isStreaming: false,
           remoteStreaming: hasQueued,
           abortController: null,

--- a/src/stores/chat-store.ts
+++ b/src/stores/chat-store.ts
@@ -588,30 +588,38 @@ export const useChatStore = create<ChatState>((set, get) => ({
       const finalStreaming = get().streamingMessage
       const finalKbSources = finalStreaming?.kbSources ?? []
       if (historySynced) {
-        // History has authoritative data — discard streamingMessage to prevent duplicates
+        // History has authoritative data — discard streamingMessage to prevent duplicates.
+        // Delay nulling streamingMessage by 300ms so ChatStageReply can run its fade-out
+        // transition before the final ChatTextBlock replaces it.
         set((s) => ({
           messages: attachKbSourcesToLatestAssistant(s.messages, finalKbSources),
-          streamingMessage: null,
           isStreaming: false,
           remoteStreaming: hasQueued,
           abortController: null,
         }))
+        setTimeout(() => {
+          useChatStore.setState({ streamingMessage: null })
+        }, 300)
       } else if (finalStreaming) {
         // Sync failed — merge streamingMessage as best-effort fallback
         set((s) => ({
           messages: [...s.messages, finalStreaming],
-          streamingMessage: null,
           isStreaming: false,
           remoteStreaming: hasQueued,
           abortController: null,
         }))
+        setTimeout(() => {
+          useChatStore.setState({ streamingMessage: null })
+        }, 300)
       } else {
         set({
-          streamingMessage: null,
           isStreaming: false,
           remoteStreaming: hasQueued,
           abortController: null,
         })
+        setTimeout(() => {
+          useChatStore.setState({ streamingMessage: null })
+        }, 300)
       }
 
       // 6. Invalidate TanStack caches so isActive flags and history data are fresh.

--- a/src/stores/chat-store.ts
+++ b/src/stores/chat-store.ts
@@ -588,38 +588,28 @@ export const useChatStore = create<ChatState>((set, get) => ({
       const finalStreaming = get().streamingMessage
       const finalKbSources = finalStreaming?.kbSources ?? []
       if (historySynced) {
-        // History has authoritative data — discard streamingMessage to prevent duplicates.
-        // Delay nulling streamingMessage by 300ms so ChatStageReply can run its fade-out
-        // transition before the final ChatTextBlock replaces it.
         set((s) => ({
           messages: attachKbSourcesToLatestAssistant(s.messages, finalKbSources),
+          streamingMessage: null,
           isStreaming: false,
           remoteStreaming: hasQueued,
           abortController: null,
         }))
-        setTimeout(() => {
-          useChatStore.setState({ streamingMessage: null })
-        }, 300)
       } else if (finalStreaming) {
-        // Sync failed — merge streamingMessage as best-effort fallback
         set((s) => ({
           messages: [...s.messages, finalStreaming],
+          streamingMessage: null,
           isStreaming: false,
           remoteStreaming: hasQueued,
           abortController: null,
         }))
-        setTimeout(() => {
-          useChatStore.setState({ streamingMessage: null })
-        }, 300)
       } else {
         set({
+          streamingMessage: null,
           isStreaming: false,
           remoteStreaming: hasQueued,
           abortController: null,
         })
-        setTimeout(() => {
-          useChatStore.setState({ streamingMessage: null })
-        }, 300)
       }
 
       // 6. Invalidate TanStack caches so isActive flags and history data are fresh.


### PR DESCRIPTION
## Summary

Upgrade TeamClaw to support OpenClaw 2026.6.6 (protocol v4). 25 files, +1018/-256.

### Gateway v4 connection
- `PROTOCOL_VERSION` 3→4, `buildConnectParams` pure function with unit tests
- Added `role:'operator'`, `family:4` (IPv4), fresh GatewayClient per SSE session for full streaming

### Chat streaming fixes
- `computeTextDelta` for v4 `deltaText/replace` protocol
- Preamble event forwarding (restores typewriter effect)
- `kind=command` tool event handling (GatewayClient receives `command` not `tool` from v4 codex-app-server runtime)

### Bug fixes
- `mergeToolCalls`: removed stale old-only branch + prefer new gateway data (2 bugs causing tool call leakage across all assistant messages)
- Tool process group: fixed `if (step.thinking) continue` skipping toolCalls on same message

### UI improvements
- Hidden thinking (ChatProcessGroup drops thinking flat steps)
- `ChatStageReply` component — grey italic overlay during tool execution
- ECharts JSON repair for LLM-generated bare newlines (Safari-compatible)
- `output/` markdown links auto-convert to download buttons

### Operations
- Sales container upgraded to `alpine/openclaw:2026.6.6-browser`
- lark plugin upgraded to 2026.6.10, feishu-ask `contracts.tools` added
- weixin duplicate + feishu entry cleanup
- containerId sync fix after rebuild

### Tests
65 tests green (15 new). E2E verified: typewriter, tool cards, done events on both lic + sales instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)